### PR TITLE
update: implement passkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ open http://localhost:3000
 ### Context
 
 - data is saved in a sqlite database
-- the app currently supports username/password and magic-link
+- the app currently supports username/password, magic-link and (sign-in with) passkey
 - for magic-link, **inspect the log to fetch the URL**
 
 ## Demo

--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,6 @@
 import { betterAuth } from 'better-auth';
 import { magicLink } from 'better-auth/plugins';
+import { passkey } from 'better-auth/plugins/passkey';
 import Database from 'better-sqlite3';
 
 export const auth = betterAuth({
@@ -27,7 +28,8 @@ export const auth = betterAuth({
         // Return a resolved promise since we're just logging
         return Promise.resolve();
       }
-    })
+    }),
+    passkey(),
   ]
   // advanced: {
   //   crossSubDomainCookies: {

--- a/src/app/routes/auth.js
+++ b/src/app/routes/auth.js
@@ -1,7 +1,7 @@
 
 import { Hono } from 'hono'
 import { html } from 'hono/html'
-import { Layout, Navigation, Message, FormSection, MagicLinkButton } from './../../components.js'
+import { Layout, Navigation, Message, FormSection, MagicLinkButton, PasskeyButton } from './../../components.js'
 import { auth } from '../../../auth.js'
 
 // Helper function to forward Set-Cookie headers from better-auth response
@@ -41,6 +41,7 @@ export default new Hono()
             </form>
 
             ${MagicLinkButton()}
+            ${PasskeyButton({ action: 'signin' })}
           `
         })}
       `
@@ -227,4 +228,31 @@ export default new Hono()
     } catch (error) {
       return c.redirect('/login?error=' + encodeURIComponent('Magic link verification failed'));
     }
+  })
+  .get('/login/passkey', (c) => {
+    return c.html(Layout({
+      title: 'Passkey Sign In',
+      children: html`
+        <h1>Sign In with Passkey</h1>
+        ${Navigation({ 
+          back: { href: '/login', text: 'Back to Login' }
+        })}
+        
+        ${Message({ 
+          error: c.req.query('error'), 
+          success: c.req.query('success') 
+        })}
+
+        ${FormSection({ 
+          children: html`
+            <form onsubmit="handlePasskeySignIn(event)">
+              <div class="form-group">
+                <input type="email" id="passkey-email" placeholder="Enter your email" required />
+              </div>
+              <button type="submit" style="background: #6f42c1; color: white;">Sign In with Passkey</button>
+            </form>
+          `
+        })}
+      `
+    }))
   })

--- a/src/app/routes/profile.js
+++ b/src/app/routes/profile.js
@@ -1,22 +1,63 @@
 import { Hono } from 'hono'
 import { html } from 'hono/html'
-import { Layout, UserInfo } from './../../components.js'
+import { Layout, UserInfo, AddPasskeySection, PasskeyList, Message } from './../../components.js'
+import { auth } from '../../../auth.js'
 
 export default new Hono()
   .get('/profile', async (c) => { // Profile page
     const user = c.get('user');
     if (!user) return c.redirect('/login?error=no+session');
 
+    const error = c.req.query('error');
+    const success = c.req.query('success');
+
+    // Fetch user's passkeys
+    let passkeys = [];
+    try {
+      passkeys = await auth.api.listPasskeys({
+        headers: c.req.raw.headers,
+      });
+    } catch (error) {
+      console.error('Failed to fetch passkeys:', error);
+    }
+
     return c.html(Layout({
       title: 'Profile',
       children: html`
         <h1>Profile</h1>
+        
+        ${Message({ error, success })}
+        
         ${UserInfo({ user })}
         
-        <form method="post" action="/logout" style="display: inline;">
-          <button type="submit">Logout</button>
-        </form>
-        <a href="/">Back to Home</a>
+        ${PasskeyList({ passkeys })}
+        
+        ${AddPasskeySection({ user })}
+        
+        <div style="margin-top: 30px;">
+          <form method="post" action="/logout" style="display: inline;">
+            <button type="submit">Logout</button>
+          </form>
+          <a href="/" style="margin-left: 20px;">Back to Home</a>
+        </div>
       `
     }));
+  })
+  .post('/profile/passkey/delete', async (c) => {
+    const user = c.get('user');
+    if (!user) return c.redirect('/login?error=no+session');
+
+    const body = await c.req.parseBody();
+    const { passkeyId } = body;
+
+    try {
+      await auth.api.deletePasskey({
+        body: { id: passkeyId },
+        headers: c.req.raw.headers,
+      });
+      return c.redirect('/profile?success=' + encodeURIComponent('Passkey deleted successfully'));
+    } catch (error) {
+      console.error('Delete passkey error:', error);
+      return c.redirect('/profile?error=' + encodeURIComponent('Failed to delete passkey'));
+    }
   })

--- a/src/components.js
+++ b/src/components.js
@@ -12,6 +12,58 @@ export const Layout = ({ title, children }) => html`
     <div class="container">
       ${children}
     </div>
+    
+    <script type="module">
+      import { createAuthClient } from "https://esm.sh/better-auth@latest/client";
+      import { passkeyClient } from "https://esm.sh/better-auth@latest/client/plugins";
+
+      const authClient = createAuthClient({
+        baseURL: "http://localhost:3000",
+        plugins: [passkeyClient()]
+      });
+
+      const handlePasskeySignIn = async (event) => {
+        event.preventDefault();
+        const email = document.getElementById('passkey-email').value;
+        
+        try {
+          await authClient.signIn.passkey({ email });
+          window.location.href = '/profile?success=' + encodeURIComponent('Signed in with passkey!');
+        } catch (error) {
+          console.error('Passkey sign in failed:', error);
+          window.location.href = '/login/passkey?error=' + encodeURIComponent('Passkey sign in failed: ' + error.message);
+        }
+      }
+
+
+      const handleAddPasskey = async (event) => {
+        event.preventDefault();
+        const email = document.getElementById('user-email').value;
+        const name = document.getElementById('user-name').value;
+        
+        try {
+          await authClient.passkey.addPasskey({ email, name });
+          window.location.href = '/profile?success=' + encodeURIComponent('Passkey added successfully!');
+        } catch (error) {
+          console.error('Add passkey failed:', error);
+          window.location.href = '/profile?error=' + encodeURIComponent('Failed to add passkey: ' + error.message);
+        }
+      }
+
+      // Attach event listeners
+      document.addEventListener('DOMContentLoaded', () => {
+        const signInForm = document.querySelector('form[onsubmit*="handlePasskeySignIn"]');
+        const addPasskeyForm = document.querySelector('form[onsubmit*="handleAddPasskey"]');
+        
+        if (signInForm) {
+          signInForm.onsubmit = handlePasskeySignIn;
+        }
+
+        if (addPasskeyForm) {
+          addPasskeyForm.onsubmit = handleAddPasskey;
+        }
+      });
+    </script>
   </body>
   </html>
 `
@@ -74,4 +126,56 @@ export const MagicLinkButton = () => html`
   <form method="get" action="/login/magic-link">
     <button type="submit" style="background: #28a745; width: 100%;">Send Magic Link</button>
   </form>
+`
+
+// Passkey button component  
+export const PasskeyButton = ({ action = 'signin' }) => html`
+  <form method="get" action="${action === 'signup' ? '/signup/passkey' : '/login/passkey'}">
+    <button 
+      type="submit" 
+      style="background: #6f42c1; width: 100%; color: white;"
+    >
+      ${action === 'signup' ? 'Sign Up with Passkey' : 'Sign In with Passkey'}
+    </button>
+  </form>
+`
+
+// Passkey list component
+export const PasskeyList = ({ passkeys }) => html`
+  ${passkeys && passkeys.length > 0 ? html`
+    <div class="form-section">
+      <h3>Your Passkeys</h3>
+      ${passkeys.map(passkey => html`
+        <div style="display: flex; justify-content: space-between; align-items: center; padding: 10px; border: 1px solid #ddd; border-radius: 5px; margin: 10px 0;">
+          <div>
+            <strong>${passkey.name || 'Unnamed Passkey'}</strong>
+            <br>
+            <small style="color: #666;">Created: ${new Date(passkey.createdAt).toLocaleDateString()}</small>
+          </div>
+          <form method="post" action="/profile/passkey/delete" style="margin: 0;">
+            <input type="hidden" name="passkeyId" value="${passkey.id}" />
+            <button type="submit" style="background: #dc3545; color: white; padding: 5px 10px; font-size: 12px;">
+              Delete
+            </button>
+          </form>
+        </div>
+      `)}
+    </div>
+  ` : ''}
+`
+
+// Add passkey component for profile page
+export const AddPasskeySection = ({ user }) => html`
+  <div class="form-section">
+    <h3>Passkey Security</h3>
+    <p>Add a passkey to your account for secure, passwordless authentication.</p>
+    
+    <form onsubmit="handleAddPasskey(event)" style="margin-top: 20px;">
+      <input type="hidden" id="user-email" value="${user.email}" />
+      <input type="hidden" id="user-name" value="${user.name}" />
+      <button type="submit" style="background: #6f42c1; color: white; padding: 12px 24px;">
+        Add Passkey to Account
+      </button>
+    </form>
+  </div>
 `

--- a/static/app.css
+++ b/static/app.css
@@ -1,5 +1,5 @@
 body { font-family: Arial, sans-serif; margin: 40px; }
-.container { max-width: 400px; }
+.container { width: 80%; max-width: 800px; margin: 0 auto; }
 .status { padding: 15px; margin: 15px 0; border-radius: 5px; }
 .logged-in { background: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
 .logged-out { background: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }

--- a/static/auth-client.js
+++ b/static/auth-client.js
@@ -1,0 +1,9 @@
+import { createAuthClient } from "better-auth/client";
+import { passkeyClient } from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+  baseURL: "http://localhost:3000",
+  plugins: [passkeyClient()]
+});
+
+export const { passkey, signIn, signUp } = authClient;


### PR DESCRIPTION
this commits implements sign-in with passkey.

in order to be able to sign in with a passkey, the user must
first register and then add a passkey to their account (on the
profile page).

the profile page also lists passkeys (when there are any) and
allows for deletion of the passkey again.

in order to enable sign-up with passkey, we'd have to figure out
a flow where the user's email address is confirmed as well, since
better-auth wants to save emails along with each password.

not confirming the email would likely allow for weird account
takeover scenarios.
