### PR TITLE
chore: skip husky install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
See https://typicode.github.io/husky/how-to.html#ci-server-and-docker