### PR TITLE
feat: sign-in and sign-up with github

### DIFF
--- a/.envrc-dist
+++ b/.envrc-dist
@@ -1,0 +1,2 @@
+export GITHUB_CLIENT_ID=
+export GITHUB_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ lerna-debug.log*
 # misc
 .DS_Store
 
-auth.db
-better-auth_migrations/
+/better-auth_migrations/
+/auth.db
+/.envrc

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Small authentication/profile prototype for Codebar.
 
 ## Local Setup
 
+For login or registration via GitHub to work, you have create an [oauth2 application](https://github.com/settings/developers). Fetch client id and secret and setup the `.envrc` from included example (in `.envrc-dist`).
+
+Then export `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` into the environment. We recommend using [direnv](https://direnv.net/).
+
+---
+
 For a new run the following:
 
 ```sh
@@ -20,6 +26,8 @@ npm ci
 npm run db:migrate
 npm run dev
 ```
+
+---
 
 View the application:
 

--- a/auth.js
+++ b/auth.js
@@ -14,6 +14,12 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    },
+  },
   telemetry: {
     enabled: false,
   },

--- a/src/app/components/login.js
+++ b/src/app/components/login.js
@@ -1,5 +1,16 @@
 import { html } from "hono/html";
 
+// GitHub login
+export const GitHubButton = ({ action = "signin", redirectUrl } = {}) => html`
+  <h2>Using GitHub</h2>
+  <button
+    onclick="handleGitHubSignIn(event)"
+    data-redirect-url="${redirectUrl || ""}"
+  >
+    ${action === "signup" ? "Sign Up with GitHub" : "Sign In with GitHub"}
+  </button>
+`;
+
 // Login form component
 export const Login = ({ redirectUrl } = {}) => html`
   <h2>Using email and password</h2>

--- a/src/app/routes/auth.js
+++ b/src/app/routes/auth.js
@@ -2,7 +2,12 @@ import { Hono } from "hono";
 import { html } from "hono/html";
 import { Layout, Navigation } from "../components/layout.js";
 import { Message, FormSection } from "../components/common.js";
-import { Login, MagicLinkButton, PasskeyButton } from "../components/login.js";
+import {
+  GitHubButton,
+  Login,
+  MagicLinkButton,
+  PasskeyButton,
+} from "../components/login.js";
 import { auth } from "../../../auth.js";
 import { getLink } from "../utils/links.js";
 import { validateRedirectUrl } from "../utils/redirect.js";
@@ -33,6 +38,7 @@ export default new Hono()
             children: html`
               ${Login({ redirectUrl })} ${MagicLinkButton({ redirectUrl })}
               ${PasskeyButton({ action: "signin", redirectUrl })}
+              ${GitHubButton({ redirectUrl })}
             `,
           })}
         `,
@@ -90,8 +96,8 @@ export default new Hono()
                   <input type="submit" value="Create Account" />
                 </fieldset>
               </form>
-
               ${MagicLinkButton({ redirectUrl })}
+              ${GitHubButton({ action: "signup", redirectUrl })}
             `,
           })}
         `,

--- a/static/auth-client.js
+++ b/static/auth-client.js
@@ -57,8 +57,28 @@ const handleAddPasskey = async (event) => {
   }
 };
 
+const handleGitHubSignIn = async (event) => {
+  event.preventDefault();
+  const button = event.target;
+  const redirectUrl = button.dataset.redirectUrl || "/profile";
+
+  try {
+    await authClient.signIn.social({
+      provider: "github",
+      callbackURL: redirectUrl,
+    });
+  } catch (error) {
+    console.error("GitHub sign in failed:", error);
+    window.location.href =
+      "/login?error=" +
+      encodeURIComponent("GitHub sign in failed: " + error.message);
+  }
+};
+
 // Attach event listeners when DOM is loaded
 document.addEventListener("DOMContentLoaded", () => {
+  window.handleGitHubSignIn = handleGitHubSignIn;
+
   const signInForm = document.querySelector(
     'form[onsubmit*="handlePasskeySignIn"]',
   );


### PR DESCRIPTION
this implements the first social provider for login/registration in
our little application. configuration requires a "github oauth2 app"
and this commit adds an example ".envrc-dist" file to use.

the implementation is purely client-side (a button is used to trigger
the better-auth methods) and doesn't require server-side calls.
