### PR TITLE
fix(setup): disable husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "db:migrate": "npx @better-auth/cli migrate --yes",
     "prettier:check": "prettier --check '**/*.{js,css,md,yml}'",
     "prettier:write": "prettier --write '**/*.{js,css,md,yml}'",
-    "prepare": "husky",
-    "lint": "eslint ."
+    "husky": "husky",
+    "lint": "eslint .",
+    "start": "node src/index.js"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.0",
@@ -18,6 +19,7 @@
     "hono": "^4.9.4"
   },
   "devDependencies": {
+    "nodemon": "^3.1.10",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.34.0",
@@ -25,7 +27,6 @@
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
-    "nodemon": "^3.1.10",
     "prettier": "^3.6.2"
   },
   "lint-staged": {


### PR DESCRIPTION
I've renamed the "prepare" task (for husky) as this task is
otherwise run each time we run "npm ci". because husky is an
optional devDependency, it interfered in the build process where
we don't want development dependencies.

the issue is elevated by the fact that husky does not get
installed, but after "npm ci", the "prepare" task tries to run
it, thus failing the entire task.

this also fixes a weirdness I encountered on my machine, where I
did not want to use husky, but every time I ran "npm ci" it would
set it up again and inject itself into my workflow.
