### PR TITLE
chore(deps): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
configure dependabot to only update direct dependencies going forward
to ensure that the updates are compatible with what we run.
